### PR TITLE
Do mount init.sql when container start

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,6 +8,7 @@ services:
     container_name: mysql
     volumes:
       - './mysql/volume:/var/lib/mysql'
+      - './mysql/init.sql:/docker-entrypoint-initdb.d/init.sql'
     environment:
       MYSQL_ROOT_PASSWORD: ThisisCS50
       MYSQL_DATABASE: pictionary

--- a/mysql/Dockerfile
+++ b/mysql/Dockerfile
@@ -1,6 +1,5 @@
 FROM mysql:8.0
 
 ADD my.cnf /etc/mysql/my.cnf
-ADD init.sql /docker-entrypoint-initdb.d/init.sql
 
 EXPOSE 13306


### PR DESCRIPTION
すいません。多分できると思います。ちょっとこのあと予定があるので、簡単に原因をつらつら書かせていただきます。
Dockerfileの中に"ADD init.sql /docker-entrypoint-initdb.d/init.sql"を書いて、初期投入SQLを実行してもらおうとしたのですが、恐らくDockerコンテナが起動する瞬間になにか初期化処理 or /docker-entrypoint-initdb.dディレクトリが再作成？作成されるのかはわからないのですが、init.sqlが消えており、画像ファイル諸々がない状態で平気な顔して立ち上がってきます。なのでDockerコンテナ起動時にinit.sqlをマウントして消えないようにしました。そしたらいけたので多分高木さんの環境でもできるはずです。よろしくおねがいします。